### PR TITLE
adapted archive-root for c3s-cmip5 and cordex

### DIFF
--- a/c4cds/mock_drs.py
+++ b/c4cds/mock_drs.py
@@ -16,7 +16,7 @@ LOGGER = logging.getLogger('PYWPS')
 class MockDRS(object):
     "A simple object to hold a DRS structure mapping."
 
-    __slots__ = ["activity", "product", "institute", "model", "experiment", "frequency",
+    __slots__ = ["institute", "model", "experiment", "frequency",
                  "modeling_realm", "MIP_table", "ensemble_member", "variable_name", "version_number",
                  "time_range", "extension", "_archive_base"]
 

--- a/c4cds/search.py
+++ b/c4cds/search.py
@@ -24,11 +24,10 @@ class C3S_CMIP5(Project):
         ensemble = ensemble or 'r1i1p1'
         variable = variable or 'tas'
         version = '*'
-        # "/opt/data/cmip5/output1/MOHC/HadGEM2-ES/historical/day/atmos/day/r1i1p1/v20120716/tas/
+        # "/opt/data/c3s-cmip5/output1/
+        #        MOHC/HadGEM2-ES/historical/day/atmos/day/r1i1p1/v20120716/tas/
         pattern = os.path.join(
             self.archive_base,
-            'c3s-cmip5',
-            '*',
             '*',
             model,
             experiment,
@@ -51,11 +50,10 @@ class CORDEX(Project):
         ensemble = ensemble or 'r1i1p1'
         variable = variable or 'tasmin'
         domain = domain or 'AFR-44i'
-        # /opt/data/cordex/output/AFR-44i/MOHC/ECMWF-ERAINT/evaluation/r1i1p1/MOHC-HadRM3P/v1/mon/tasmin/v20131211/
+        # /opt/data/cordex/output/
+        #      AFR-44i/MOHC/ECMWF-ERAINT/evaluation/r1i1p1/MOHC-HadRM3P/v1/mon/tasmin/v20131211/
         pattern = os.path.join(
             self.archive_base,
-            'cordex',
-            '*',
             domain,
             '*',
             '*',

--- a/c4cds/util.py
+++ b/c4cds/util.py
@@ -82,9 +82,19 @@ def get_grid_cell_area_variable(var_id, path, archive_base=None):
 
     d = map_to_drs(path, archive_base=archive_base)
     cell_areas_path = os.path.join(
-        archive_base, d.activity, d.product, d.institute,
-        d.model, d.experiment, "fx", d.modeling_realm, "fx", "r0i0p0",
-        "*", acm, acm_file_name)
+        archive_base,
+        # d.activity,
+        # d.product,
+        d.institute,
+        d.model,
+        d.experiment,
+        "fx",
+        d.modeling_realm,
+        "fx",
+        "r0i0p0",
+        "*",
+        acm,
+        acm_file_name)
 
     files = glob.glob(cell_areas_path)
     if not files:

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -3,6 +3,11 @@
 Configuration
 =============
 
+.. warning::
+
+  Please read the PyWPS documentation_ to find details about possible configuration options.
+
+
 Command-line options
 --------------------
 
@@ -39,8 +44,8 @@ For example change the hostname (*demo.org*) and logging level:
    level = DEBUG
 
    [data]
-   c3s_cmip5_archive_root = /data/C3S_CMIP5
-   cordex_archive_root = /data/CORDEX
+   c3s_cmip5_archive_root = /data/c3s-cmip5/output1
+   cordex_archive_root = /data/cordex/output
 
 .. NOTE:: You need to configure the path to the local data archives for C3S_CMIP5 and CORDEX.
 
@@ -53,3 +58,4 @@ Start the service with your custom configuration:
 
 
 .. _PyWPS: http://pywps.org/
+.. _documentation: https://pywps.readthedocs.io/en/master/configuration.html

--- a/etc/sample-custom.cfg
+++ b/etc/sample-custom.cfg
@@ -4,3 +4,7 @@ outputurl = http://demo.org:5000/outputs
 
 [logging]
 level = DEBUG
+
+[data]
+c3s_cmip5_archive_root = /data/c3s-cmip5/output1
+cordex_archive_root = /data/cordex/output

--- a/tests/common.py
+++ b/tests/common.py
@@ -8,9 +8,11 @@ def resource_file(filepath):
 
 
 ARCHIVE_BASE = resource_file('data')
+C3S_CMIP5_ARCHIVE_BASE = os.path.join(ARCHIVE_BASE, 'c3s-cmip5', 'output1')
+CORDEX_ARCHIVE_BASE = os.path.join(ARCHIVE_BASE, 'cordex', 'output')
 
-C3S_CMIP5_NC = ARCHIVE_BASE + '/c3s-cmip5/output1/MOHC/HadGEM2-ES/historical/mon/atmos/Amon/r1i1p1/tas/v20120928/tas_Amon_HadGEM2-ES_historical_r1i1p1_186001-186012.nc'  # noqa
-CORDEX_NC = ARCHIVE_BASE + "/cordex/output/AFR-44i/MOHC/ECMWF-ERAINT/evaluation/r1i1p1/MOHC-HadRM3P/v1/mon/tasmin/v20131211/tasmin_AFR-44i_ECMWF-ERAINT_evaluation_r1i1p1_MOHC-HadRM3P_v1_mon_199001-199012.nc"  # noqa
+C3S_CMIP5_NC = C3S_CMIP5_ARCHIVE_BASE + '/MOHC/HadGEM2-ES/historical/mon/atmos/Amon/r1i1p1/tas/v20120928/tas_Amon_HadGEM2-ES_historical_r1i1p1_186001-186012.nc'  # noqa
+CORDEX_NC = CORDEX_ARCHIVE_BASE + "/AFR-44i/MOHC/ECMWF-ERAINT/evaluation/r1i1p1/MOHC-HadRM3P/v1/mon/tasmin/v20131211/tasmin_AFR-44i_ECMWF-ERAINT_evaluation_r1i1p1_MOHC-HadRM3P_v1_mon_199001-199012.nc"  # noqa
 
 
 def resource_ok(filename):

--- a/tests/resources/test.cfg
+++ b/tests/resources/test.cfg
@@ -2,5 +2,5 @@
 level = DEBUG
 
 [data]
-c3s_cmip5_archive_root = tests/resources/data
-cordex_archive_root = tests/resources/data
+c3s_cmip5_archive_root = tests/resources/data/c3s-cmip5/output1
+cordex_archive_root = tests/resources/data/cordex/output

--- a/tests/test_mock_drs.py
+++ b/tests/test_mock_drs.py
@@ -2,13 +2,13 @@ import pytest
 
 from c4cds.mock_drs import MockDRS
 
-from .common import C3S_CMIP5_NC, ARCHIVE_BASE
+from .common import C3S_CMIP5_NC, C3S_CMIP5_ARCHIVE_BASE
 
-FX_NC = "/cmip5/output1/MPI-M/MPI-ESM-P/piControl/fx/atmos/fx/r0i0p0/latest/orog/orog_fx_MPI-ESM-P_piControl_r0i0p0.nc"
+FX_NC = "/MPI-M/MPI-ESM-P/piControl/fx/atmos/fx/r0i0p0/latest/orog/orog_fx_MPI-ESM-P_piControl_r0i0p0.nc"
 
 
 def test_mock_drs_cmip5_as_iter():
-    m = MockDRS(C3S_CMIP5_NC, archive_base=ARCHIVE_BASE)
+    m = MockDRS(C3S_CMIP5_NC, archive_base=C3S_CMIP5_ARCHIVE_BASE)
     for i in m.as_iter():
         print(i)
     assert m.experiment == 'historical'
@@ -17,7 +17,7 @@ def test_mock_drs_cmip5_as_iter():
 
 
 def test_mock_drs_cmip5_as_dict():
-    m = MockDRS(C3S_CMIP5_NC, archive_base=ARCHIVE_BASE)
+    m = MockDRS(C3S_CMIP5_NC, archive_base=C3S_CMIP5_ARCHIVE_BASE)
     print(m.as_dict())
 
 

--- a/tests/test_regridder.py
+++ b/tests/test_regridder.py
@@ -4,7 +4,7 @@ import os
 
 from c4cds.regridder import Regridder, GLOBAL, REGIONAL
 
-from .common import C3S_CMIP5_NC, CORDEX_NC, ARCHIVE_BASE, resource_ok
+from .common import C3S_CMIP5_NC, CORDEX_NC, C3S_CMIP5_ARCHIVE_BASE, CORDEX_ARCHIVE_BASE, resource_ok
 
 
 def test_create_output_dir():
@@ -14,7 +14,7 @@ def test_create_output_dir():
 
 
 def test_get_grid_definition_file():
-    regridder = Regridder(archive_base=ARCHIVE_BASE)
+    regridder = Regridder(archive_base=CORDEX_ARCHIVE_BASE)
     assert 'grid_files/ll1deg_grid.nc' in regridder.get_grid_definition_file(
         C3S_CMIP5_NC, domain_type=GLOBAL)
     assert 'grid_files/ll0.5deg_AFR-44i.nc' in regridder.get_grid_definition_file(
@@ -24,26 +24,26 @@ def test_get_grid_definition_file():
 @pytest.mark.skipif(not resource_ok(CORDEX_NC),
                     reason="Test data not available.")
 def test_validate_input_grid():
-    regridder = Regridder(archive_base=ARCHIVE_BASE)
+    regridder = Regridder(archive_base=CORDEX_ARCHIVE_BASE)
     regridder.validate_input_grid(CORDEX_NC)
 
 
 @pytest.mark.skipif(not resource_ok(CORDEX_NC),
                     reason="Test data not available.")
 def test_validate_regridded_file_cordex():
-    regridder = Regridder(archive_base=ARCHIVE_BASE)
+    regridder = Regridder(archive_base=CORDEX_ARCHIVE_BASE)
     regridder.validate_regridded_file(CORDEX_NC, REGIONAL)
 
 
 @pytest.mark.skip(reason='no regridded file')
 def test_validate_regridded_file_cmip5():
-    regridder = Regridder(archive_base=ARCHIVE_BASE)
+    regridder = Regridder(archive_base=C3S_CMIP5_ARCHIVE_BASE)
     regridder.validate_regridded_file(C3S_CMIP5_NC, GLOBAL)
 
 
 @pytest.mark.skip(reason="no grid file for CORDEX.")
 def test_regrid_cordex():
-    regridder = Regridder(archive_base=ARCHIVE_BASE)
+    regridder = Regridder(archive_base=CORDEX_ARCHIVE_BASE)
     assert '0.5_deg/tasmin_AFR-44i_ECMWF-ERAINT_evaluation_r1i1p1_MOHC-HadRM3P_v1_mon_199001-199012.nc' \
         in regridder.regrid(CORDEX_NC, REGIONAL)
 
@@ -51,6 +51,6 @@ def test_regrid_cordex():
 @pytest.mark.skipif(not resource_ok(C3S_CMIP5_NC),
                     reason="Test data not available.")
 def test_regrid_cmip5():
-    regridder = Regridder(archive_base=ARCHIVE_BASE)
+    regridder = Regridder(archive_base=C3S_CMIP5_ARCHIVE_BASE)
     assert '1_deg/tas_Amon_HadGEM2-ES_historical_r1i1p1_186001-186012.nc' \
         in regridder.regrid(C3S_CMIP5_NC, GLOBAL)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -3,7 +3,7 @@ import pytest
 from c4cds.search import Search, C3S_CMIP5, CORDEX
 from c4cds.search import filter_by_year
 
-from .common import ARCHIVE_BASE, C3S_CMIP5_NC, CORDEX_NC, resource_ok
+from .common import C3S_CMIP5_ARCHIVE_BASE, CORDEX_ARCHIVE_BASE, C3S_CMIP5_NC, CORDEX_NC, resource_ok
 
 
 def test_filter_by_year():
@@ -15,19 +15,19 @@ def test_filter_by_year():
 
 
 def test_c3s_cmip5_search_pattern():
-    cmip5 = C3S_CMIP5(ARCHIVE_BASE)
+    cmip5 = C3S_CMIP5(C3S_CMIP5_ARCHIVE_BASE)
     assert cmip5.search_pattern(
         model='HadGEM2-ES',
         experiment='historical',
         ensemble='r1i1p1',
         variable='tas',
-    ) == ARCHIVE_BASE + '/c3s-cmip5/*/*/HadGEM2-ES/historical/mon/atmos/*/r1i1p1/tas/*/*'
+    ) == C3S_CMIP5_ARCHIVE_BASE + '/*/HadGEM2-ES/historical/mon/atmos/*/r1i1p1/tas/*/*'
 
 
 @pytest.mark.skipif(not resource_ok(C3S_CMIP5_NC),
                     reason="Test data not available.")
 def test_search_c3s_cmip5():
-    search = Search(ARCHIVE_BASE)
+    search = Search(C3S_CMIP5_ARCHIVE_BASE)
     assert 'tas_Amon_HadGEM2-ES_historical_r1i1p1_186001-186012.nc' in search.search_cmip5(
         model='HadGEM2-ES',
         experiment='historical',
@@ -38,20 +38,20 @@ def test_search_c3s_cmip5():
 
 
 def test_cordex_search_pattern():
-    cordex = CORDEX(ARCHIVE_BASE)
+    cordex = CORDEX(CORDEX_ARCHIVE_BASE)
     assert cordex.search_pattern(
         domain='AFR-44i',
         experiment='evaluation',
         ensemble='r1i1p1',
         model='MOHC-HadRM3P',
         variable='tasmin'
-    ) == ARCHIVE_BASE + '/cordex/*/AFR-44i/*/*/evaluation/r1i1p1/MOHC-HadRM3P/*/mon/tasmin/*/*'
+    ) == CORDEX_ARCHIVE_BASE + '/AFR-44i/*/*/evaluation/r1i1p1/MOHC-HadRM3P/*/mon/tasmin/*/*'
 
 
 @pytest.mark.skipif(not resource_ok(CORDEX_NC),
                     reason="Test data not available.")
 def test_search_cordex():
-    search = Search(ARCHIVE_BASE)
+    search = Search(CORDEX_ARCHIVE_BASE)
     assert 'tasmin_AFR-44i_ECMWF-ERAINT_evaluation_r1i1p1_MOHC-HadRM3P_v1_mon_199001-199012.nc' in search.search_cordex(
         model='MOHC-HadRM3P',
         domain='AFR-44i',

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,7 +2,7 @@ import pytest
 
 from c4cds import util
 
-from .common import CORDEX_NC, C3S_CMIP5_NC, ARCHIVE_BASE, resource_ok
+from .common import CORDEX_NC, C3S_CMIP5_NC, C3S_CMIP5_ARCHIVE_BASE, CORDEX_ARCHIVE_BASE, resource_ok
 
 
 def test_guess_variable_name():
@@ -39,7 +39,7 @@ def test_convert_to_netcdf3():
 
 
 def test_map_to_drs_cmip5():
-    assert util.map_to_drs(C3S_CMIP5_NC, archive_base=ARCHIVE_BASE) is not None
+    assert util.map_to_drs(C3S_CMIP5_NC, archive_base=C3S_CMIP5_ARCHIVE_BASE) is not None
 
 
 @pytest.mark.skip(reason='not working')
@@ -47,7 +47,7 @@ def test_get_grid_cell_area_variable_cordex():
     assert util.get_grid_cell_area_variable(
         var_id='tasmin',
         path=CORDEX_NC,
-        archive_base=ARCHIVE_BASE) is not None
+        archive_base=CORDEX_ARCHIVE_BASE) is not None
 
 
 @pytest.mark.skip(reason='no fx in c3s-cmip5')
@@ -55,5 +55,5 @@ def test_get_grid_cell_area_variable_cmip5():
     assert util.get_grid_cell_area_variable(
         var_id='tas',
         path=C3S_CMIP5_NC,
-        archive_base=ARCHIVE_BASE) == \
+        archive_base=C3S_CMIP5_ARCHIVE_BASE) == \
         '/opt/data/c3s-cmip5/output1/MOHC/HadGEM2-ES/historical/fx/atmos/fx/r0i0p0/latest/areacella/areacella_fx_HadGEM2-ES_historical_r0i0p0.nc'  # noqa


### PR DESCRIPTION
## Overview

This PR adapts the `archive_root` configuration for c3s-cmip5 and cordex.

Changes:

* Updated `archive_root` path: relative path starts with *institute* (cmip5) or *domain* (cordex). 
* Updated tests.
* Updated docs.

## Related Issue / Discussion

## Additional Information


