### PR TITLE
skip wrong time periods

### DIFF
--- a/c4cds/search.py
+++ b/c4cds/search.py
@@ -72,7 +72,11 @@ class CORDEX(Project):
 def filter_by_year(files, start_year=None, end_year=None):
     result = []
     for filepath in files:
-        f_start_year, f_end_year = util.parse_time_period(filepath)
+        try:
+            f_start_year, f_end_year = util.parse_time_period(filepath)
+        except Exception:
+            LOGGER.warn("could not parse time period: {}".format(filepath))
+            continue
         if end_year is not None and end_year < f_start_year:
             continue
         elif start_year is not None and start_year > f_end_year:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -26,6 +26,12 @@ def test_parse_time_period():
         '/path/to/tasmin_AFR-44i_ECMWF-ERAINT_evaluation_r1i1p1_MOHC-HadRM3P_v1_day_19900101-19901231.nc'
     ) == (1990, 1990)
 
+    # false pattern
+    with pytest.raises(Exception):
+        util.parse_time_period(
+            '/path/to/data/cordex/output/EUR-44i/MOHC/ECMWF-ERAINT/evaluation/r1i1p1/MOHC-HadRM3P/v1/mon/tas/files/d20131212'  # noqa
+        )
+
 
 def test_get_variable_name():
     assert util.get_variable_name(CORDEX_NC) == 'tasmin'


### PR DESCRIPTION
## Overview

This PR fixes an issue with file pattern matching. It skips where the time period can not be parsed.


## Related Issue / Discussion

## Additional Information
